### PR TITLE
Update LSTNet.py

### DIFF
--- a/models/LSTNet.py
+++ b/models/LSTNet.py
@@ -13,7 +13,7 @@ class Model(nn.Module):
         self.hidS = args.hidSkip;
         self.Ck = args.CNN_kernel;
         self.skip = args.skip;
-        self.pt = (self.P - self.Ck)/self.skip
+        self.pt = int((self.P - self.Ck)/self.skip)
         self.hw = args.highway_window
         self.conv1 = nn.Conv2d(1, self.hidC, kernel_size = (self.Ck, self.m));
         self.GRU1 = nn.GRU(self.hidC, self.hidR);


### PR DESCRIPTION
Resolves a Runtime error occurring based on this:

Traceback (most recent call last):
  File "main.py", line 149, in <module>
    train_loss = train(Data, Data.train[0], Data.train[1], model, criterion, optim, args.batch_size)
  File "main.py", line 55, in train
    output = model(X);
  File "D:\Anaconda2\envs\py3\lib\site-packages\torch\nn\modules\module.py", line 491, in __call__
    result = self.forward(*input, **kwargs)
  File "D:\Python\multivariate-time-series-data\models\LSTNet.py", line 53, in forward
    s = s.view(batch_size, self.hidC, self.pt, self.skip);
RuntimeError: invalid argument 2: size '[128 x 100 x 6 x 24]' is invalid for input with 2073600 elements at ..\src\TH\THStorage.c:41